### PR TITLE
Put the outer plan through hash before it gets passed to hashjoin

### DIFF
--- a/Project/createplan.c
+++ b/Project/createplan.c
@@ -1450,7 +1450,8 @@ create_hashjoin_plan(PlannerInfo *root,
 	List	   *otherclauses;
 	List	   *hashclauses;
 	HashJoin   *join_plan;
-	Hash	   *hash_plan;
+	Hash	   *inner_hash_plan;
+	Hash	   *outer_hash_plan;
 	// CSI3530 IL FAUT AJOUTER UN AUTRE HASH_PLAN, DEUX AU TOTAL (INNER ET OUTER)
 	// CSI3130 You must add another hash plan, two in total (inner and outer)
 
@@ -1494,13 +1495,14 @@ create_hashjoin_plan(PlannerInfo *root,
 	 */
 	// CSI3530 Il faut construire le hash node et le hash join node pour les deux hash plans (outer et inner)
 	// CSI3130 You must build the hash node and hash join node for both hash plans (outer and inner)
-	hash_plan = make_hash(inner_plan);
+	inner_hash_plan = make_hash(inner_plan);
+	outer_hash_plan = make_hash(outer_plan);
 	join_plan = make_hashjoin(tlist,
 							  joinclauses,
 							  otherclauses,
 							  hashclauses,
-							  outer_plan,
-							  (Plan *) hash_plan,
+							  (Plan *) outer_hash_plan,
+							  (Plan *) inner_hash_plan,
 							  // CSI3530 //CSI3130 ...
 							  best_path->jpath.jointype);
 


### PR DESCRIPTION
the first 10%
• Change the optimizer so that both the inner and outer relations are first processed by hash nodes before being processed by the hash join operator. In the current implementation, only the inner relation is hashed, as described in Section 2. The hashing nodes is necessary to incrementally retrieve a tuple from each relation, insert it into the corresponding hash table and return it to the hash join node. This effect can be implemented by modifying the function that creates the hash join node in the planner component, which can found in the file createplan.c. (10%)